### PR TITLE
Update CntkIntegration example to use CrossValidationUtilities

### DIFF
--- a/src/SharpLearning.Examples.Integration/SharpLearning.Examples.Integration.csproj
+++ b/src/SharpLearning.Examples.Integration/SharpLearning.Examples.Integration.csproj
@@ -55,31 +55,34 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="SharpLearning.Common.Interfaces, Version=0.31.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SharpLearning.Common.Interfaces.0.31.3\lib\net461\SharpLearning.Common.Interfaces.dll</HintPath>
+    <Reference Include="SharpLearning.Common.Interfaces, Version=0.31.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SharpLearning.Common.Interfaces.0.31.4\lib\net461\SharpLearning.Common.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="SharpLearning.Containers, Version=0.31.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SharpLearning.Containers.0.31.3\lib\net461\SharpLearning.Containers.dll</HintPath>
+    <Reference Include="SharpLearning.Containers, Version=0.31.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SharpLearning.Containers.0.31.4\lib\net461\SharpLearning.Containers.dll</HintPath>
     </Reference>
-    <Reference Include="SharpLearning.CrossValidation, Version=0.31.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SharpLearning.CrossValidation.0.31.3\lib\net461\SharpLearning.CrossValidation.dll</HintPath>
+    <Reference Include="SharpLearning.CrossValidation, Version=0.31.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SharpLearning.CrossValidation.0.31.4\lib\net461\SharpLearning.CrossValidation.dll</HintPath>
     </Reference>
-    <Reference Include="SharpLearning.FeatureTransformations, Version=0.31.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SharpLearning.FeatureTransformations.0.31.3\lib\net461\SharpLearning.FeatureTransformations.dll</HintPath>
+    <Reference Include="SharpLearning.FeatureTransformations, Version=0.31.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SharpLearning.FeatureTransformations.0.31.4\lib\net461\SharpLearning.FeatureTransformations.dll</HintPath>
     </Reference>
-    <Reference Include="SharpLearning.InputOutput, Version=0.31.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SharpLearning.InputOutput.0.31.3\lib\net461\SharpLearning.InputOutput.dll</HintPath>
+    <Reference Include="SharpLearning.InputOutput, Version=0.31.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SharpLearning.InputOutput.0.31.4\lib\net461\SharpLearning.InputOutput.dll</HintPath>
     </Reference>
-    <Reference Include="SharpLearning.Metrics, Version=0.31.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SharpLearning.Metrics.0.31.3\lib\net461\SharpLearning.Metrics.dll</HintPath>
+    <Reference Include="SharpLearning.Metrics, Version=0.31.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SharpLearning.Metrics.0.31.4\lib\net461\SharpLearning.Metrics.dll</HintPath>
     </Reference>
-    <Reference Include="SharpLearning.Neural, Version=0.31.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SharpLearning.Neural.0.31.3\lib\net461\SharpLearning.Neural.dll</HintPath>
+    <Reference Include="SharpLearning.Neural, Version=0.31.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SharpLearning.Neural.0.31.4\lib\net461\SharpLearning.Neural.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CntkIntegrations.cs" />
@@ -87,6 +90,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />

--- a/src/SharpLearning.Examples.Integration/app.config
+++ b/src/SharpLearning.Examples.Integration/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/SharpLearning.Examples.Integration/packages.config
+++ b/src/SharpLearning.Examples.Integration/packages.config
@@ -10,11 +10,12 @@
   <package id="MathNet.Numerics.MKL.Win" version="2.3.0" targetFramework="net461" />
   <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net461" />
   <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net461" />
-  <package id="SharpLearning.Common.Interfaces" version="0.31.3" targetFramework="net461" />
-  <package id="SharpLearning.Containers" version="0.31.3" targetFramework="net461" />
-  <package id="SharpLearning.CrossValidation" version="0.31.3" targetFramework="net461" />
-  <package id="SharpLearning.FeatureTransformations" version="0.31.3" targetFramework="net461" />
-  <package id="SharpLearning.InputOutput" version="0.31.3" targetFramework="net461" />
-  <package id="SharpLearning.Metrics" version="0.31.3" targetFramework="net461" />
-  <package id="SharpLearning.Neural" version="0.31.3" targetFramework="net461" />
+  <package id="SharpLearning.Common.Interfaces" version="0.31.4" targetFramework="net461" />
+  <package id="SharpLearning.Containers" version="0.31.4" targetFramework="net461" />
+  <package id="SharpLearning.CrossValidation" version="0.31.4" targetFramework="net461" />
+  <package id="SharpLearning.FeatureTransformations" version="0.31.4" targetFramework="net461" />
+  <package id="SharpLearning.InputOutput" version="0.31.4" targetFramework="net461" />
+  <package id="SharpLearning.Metrics" version="0.31.4" targetFramework="net461" />
+  <package id="SharpLearning.Neural" version="0.31.4" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
A small update to the `SharpLearning_With_Cntk_Example`. This now uses the CrossValidationUtilities for generating the K-Fold cross validation sets.